### PR TITLE
Changed KUBERNETES_PUBLIC_ADDRESS in 01-infrastructure.md .…

### DIFF
--- a/docs/01-infrastructure.md
+++ b/docs/01-infrastructure.md
@@ -81,7 +81,7 @@ Create a public IP address that will be used by remote clients to connect to the
 
 ```
 neutron floatingip-create FloatingIP-external-monsoon3
-export KUBERNETES_PUBLIC_ADDRESS=10.47.40.96
+export KUBERNETES_PUBLIC_ADDRESS=10.47.40.33
 ```
 
 ### Create Firewall Rules


### PR DESCRIPTION
Hi All
In 01-infrastructure.md KUBERNETES_PUBLIC_ADDRESS set to 10.47.40.96
```
neutron floatingip-create FloatingIP-external-monsoon3
export KUBERNETES_PUBLIC_ADDRESS=10.47.40.96
```
But in 04-kubectl.md and 05-kubernetes-controller.md KUBERNETES_PUBLIC_ADDRESS set to 10.47.40.33
```
Configure Kubectl

In this section you will configure the kubectl client to point to the Kubernetes API Server Frontend Load Balancer.

Use the load balancer's floating ip from earlier:

KUBERNETES_PUBLIC_ADDRESS=10.47.40.33
```

```
Attach our previously reserved floating-ip:

neutron port-list
+--------------------------------------+----------------------------------------------------------------------------------------+-------------------+------------------------------------------------------------------------------------+
| id                                   | name                                                                                   | mac_address       | fixed_ips                                                                          |
+--------------------------------------+----------------------------------------------------------------------------------------+-------------------+------------------------------------------------------------------------------------+
| 08899903-ca6c-42a0-b210-f8a380dfcd80 | loadbalancer-abb068fc-d6ed-4a81-b424-b95a5f775bcc                                      | fa:16:3e:8b:54:99 | {"subnet_id": "83aab941-87f4-4372-9fbc-9f702092e3cf", "ip_address": "10.180.0.7"}  |
...
+--------------------------------------+----------------------------------------------------------------------------------------+-------------------+------------------------------------------------------------------------------------+


neutron floatingip-list
+--------------------------------------+------------------+---------------------+--------------------------------------+
| id                                   | fixed_ip_address | floating_ip_address | port_id                              |
+--------------------------------------+------------------+---------------------+--------------------------------------+
| cacce782-68b6-4944-87c6-3640c94f7159 |                  | 10.47.40.33         |                                      |
| 9a4bff45-d72c-4777-a5b1-abe5e76de613 | 10.180.0.30      | 10.47.41.49         | 848396d3-5e18-4410-9a7f-949295428e3f |
+--------------------------------------+------------------+---------------------+--------------------------------------+

neutron floatingip-associate cacce782-68b6-4944-87c6-3640c94f7159 08899903-ca6c-42a0-b210-f8a380dfcd80

```